### PR TITLE
remove defineCustomElements

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "@capacitor/core": "^1.1.0",
-    "@ionic/core": "ˆ4.6.0",
+    "@ionic/core": "^4.6.0",
     "@ionic/pwa-elements": "^1.3.0",
-    "@stencil/core": "ˆ1.1.3"
+    "@stencil/core": "^1.1.3"
   }
 }

--- a/src/global/app.ts
+++ b/src/global/app.ts
@@ -1,8 +1,5 @@
 import '@ionic/core';
 import '@ionic/pwa-elements';
-import { defineCustomElements } from '@ionic/pwa-elements/loader';
-
-defineCustomElements(window);
 
 // import { setupConfig } from '@ionic/core';
 


### PR DESCRIPTION
I don't think you need the `defineCustomElements `, it works fine without it.

Also you had `ˆ` instead of `^` in some packages and failed to install